### PR TITLE
fix(poke.io.js): fix loadProtoFile from node_modules folder to be != null

### DIFF
--- a/poke.io.js
+++ b/poke.io.js
@@ -14,7 +14,7 @@ const Logins = require('./logins');
 
 let builder = ProtoBuf.loadProtoFile('pokemon.proto');
 if (builder === null) {
-    builder = ProtoBuf.loadProtoFile('./node_modules/pokemon-go-node-api/pokemon.proto');
+    builder = ProtoBuf.loadProtoFile(__dirname + '/pokemon.proto');
 }
 
 const pokemonProto = builder.build();


### PR DESCRIPTION
…null

Previously when you install module from npm it was not able to start
because of NULL builder - __dirname already was at
node_modules/pokemon-go-node-api, so there was no point in looking for
'./node_modules/pokemon-go-node-api/pokemon.proto’.
