### PR TITLE
Move `tape` to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
     "protobufjs": "^5.0.1",
     "request": "^2.73.0",
     "s2geometry-node": "^1.1.0",
-    "tape": "^4.6.0",
     "bytebuffer": "latest"
+  },
+  "devDependencies": {
+    "tape": "^4.6.0",
   },
   "scripts": {
     "test": "istanbul cover node_modules/tape/bin/tape tests/**/*.js"


### PR DESCRIPTION
The `tape` package is only for testing and therefore doesn't need to be part of the published package.
