### PR TITLE
Avoid server crash if geocoder can't find the location

### DIFF
--- a/poke.io.js
+++ b/poke.io.js
@@ -385,7 +385,7 @@ function Pokeio() {
             self.playerInfo.altitude = location.coords.altitude || self.playerInfo.altitude;
 
             geocoder.reverseGeocode.apply(geocoder, _toConsumableArray(GetCoords(self)).concat([function (err, data) {
-                if (data.status !== 'ZERO_RESULTS' && data.results && data.results[0]) {
+                if (data && data.status !== 'ZERO_RESULTS' && data.results && data.results[0]) {
                     self.playerInfo.locationName = data.results[0].formatted_address;
                 }
 

--- a/poke.io.js
+++ b/poke.io.js
@@ -385,7 +385,7 @@ function Pokeio() {
             self.playerInfo.altitude = location.coords.altitude || self.playerInfo.altitude;
 
             geocoder.reverseGeocode.apply(geocoder, _toConsumableArray(GetCoords(self)).concat([function (err, data) {
-                if (data.status !== 'ZERO_RESULTS') {
+                if (data.status !== 'ZERO_RESULTS' && data.results && data.results[0]) {
                     self.playerInfo.locationName = data.results[0].formatted_address;
                 }
 


### PR DESCRIPTION
If geocoder can't find info about the place that you are trying to reach (via coords) the app crashes. 
