### PR TITLE
Let protobuf do the packing

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "protobufjs": "^5.0.1",
     "request": "^2.73.0",
     "s2geometry-node": "^1.1.0",
-    "tape": "^4.6.0",
-    "bytebuffer": "latest"
+    "tape": "^4.6.0"
   },
   "scripts": {
     "test": "istanbul cover node_modules/tape/bin/tape tests/**/*.js"

--- a/poke.io.js
+++ b/poke.io.js
@@ -7,7 +7,6 @@ var geocoder = require('geocoder');
 var events = require('events');
 var ProtoBuf = require('protobufjs');
 var GoogleOAuth = require('gpsoauthnode');
-var ByteBuffer = require('bytebuffer');
 var fs = require('fs');
 var s2 = require('s2geometry-node');
 
@@ -237,22 +236,17 @@ function Pokeio() {
         var accessToken = _self$playerInfo2.accessToken;
 
 
-        var nullbytes = new Buffer(21);
+        var nullbytes = new Array(21);
         nullbytes.fill(0);
 
         // Generating walk data using s2 geometry
         var walk = getNeighbors(self.playerInfo.latitude, self.playerInfo.longitude).sort(function (a, b) {
             return a > b;
         });
-        var buffer = new ByteBuffer(21 * 10).LE();
-        walk.forEach(function (elem) {
-            buffer.writeVarint64(elem);
-        });
 
         // Creating MessageQuad for Requests type=106
-        buffer.flip();
         var walkData = new RequestEnvelop.MessageQuad({
-            'f1': buffer.toBuffer(),
+            'f1': walk,
             'f2': nullbytes,
             'lat': self.playerInfo.latitude,
             'long': self.playerInfo.longitude

--- a/pokemon.proto
+++ b/pokemon.proto
@@ -38,8 +38,8 @@ message RequestEnvelop {
   }
 
   message MessageQuad {
-    repeated bytes f1 = 1;
-    required bytes f2 = 2;
+    repeated uint64 f1 = 1 [packed=true];
+    repeated int64 f2 = 2 [packed=true];
     required double lat = 3;
     required double long = 4;
   }


### PR DESCRIPTION
This fixes the issue in (https://github.com/Armax/Pokemon-GO-node-api/issues/59) and (https://github.com/Armax/Pokemon-GO-node-api/issues/57).  The issue was not with the s2 library, but how the ByteBuffer was manually packing the bytes.  This lets the proto do it for us.
