### PR TITLE
Avoid server crash with the login unexpected errors

### DIFF
--- a/logins.js
+++ b/logins.js
@@ -77,6 +77,7 @@ module.exports = {
                     }
 
                     token = body.split('token=')[1];
+                    if(!token) return callback(new Error('Login failed'), null);
                     token = token.split('&')[0];
 
                     if (!token) {

--- a/logins.js
+++ b/logins.js
@@ -24,7 +24,12 @@ module.exports = {
             if (err) {
                 return callback(err, null);
             }
-            data = JSON.parse(body);
+            
+            try {
+              data = JSON.parse(body);
+            }catch(err){
+              return callback(err, null);
+            }
 
             options = {
                 url: login_url,


### PR DESCRIPTION
Sometimes, when the connection of the pokemonClub server login doesn't go as it should we dont have a token as the response.
