### PR TITLE
Fixed CaptureAward message

### DIFF
--- a/pokemon.proto
+++ b/pokemon.proto
@@ -974,10 +974,10 @@ message ResponseEnvelop {
   }
 
   message CaptureAward {
-      repeated ActivityType ActivityType = 1;
-      repeated int32 XP = 2;
-      repeated int32 Candy = 3;
-      repeated int32 Stardust = 4;
+      repeated ActivityType ActivityType = 1 [packed=true];
+      repeated int32 XP = 2 [packed=true];
+      repeated int32 Candy = 3 [packed=true];
+      repeated int32 Stardust = 4 [packed=true];
   }
 
   message CaptureProbability {


### PR DESCRIPTION
ProtoBufjs throws an illegal wire type error if the fields are not explicitly marked as packed. According to the error message, the message has a wire type of 2, which, according to the Protocol Buffer docs, is used for packed fields among other things. The second example in example.js parses CatchPokemonResponse s after this change.
