### PR TITLE
Change deployed_fort_id to type string

### DIFF
--- a/pokemon.proto
+++ b/pokemon.proto
@@ -291,7 +291,7 @@ message ResponseEnvelop {
     	optional int32 stamina_max = 5;
     	optional PokemonMove move_1 = 6;
     	optional PokemonMove move_2 = 7;
-    	optional int32 deployed_fort_id = 8;
+    	optional string deployed_fort_id = 8;
     	optional string owner_name = 9;
     	optional bool is_egg = 10;
     	optional double egg_km_walked_target = 11;


### PR DESCRIPTION
- Fixes
  Error: Illegal wire type for field Message.Field .ResponseEnvelop.PokemonData.deployed_fort_id: 2 (0 expected)
