### PR TITLE
Gym-assigned Pokemon crash fix

### DIFF
--- a/pokemon.proto
+++ b/pokemon.proto
@@ -325,7 +325,7 @@ message ResponseEnvelop {
       optional int32 stamina_max = 5;
       optional PokemonMove move_1 = 6;
       optional PokemonMove move_2 = 7;
-      optional int32 deployed_fort_id = 8;
+      optional string deployed_fort_id = 8;
       optional string owner_name = 9;
       optional bool is_egg = 10;
       optional int32 egg_km_walked_target = 11;


### PR DESCRIPTION
PokemonData had the correct data type, but Pokemon did not. This resulted in inventories (got with `GetInventory`) that had a Pokemon assigned to a gym crashing due to the wrong data type being used. This PR changes from int32 to string in `Pokemon`.
