### PR TITLE
Patch pogo signature npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "gpsoauthnode": "^0.0.5",
     "istanbul": "^0.4.4",
     "long": "^3.2.0",
-    "node-pogo-signature": "https://github.com/SpencerSharkey/node-pogo-signature.git",
+    "node-pogo-signature": "^2.0.0",
     "protobufjs": "^5.0.1",
     "request": "^2.73.0",
     "s2geometry-node": "^1.3.0",


### PR DESCRIPTION
I published the node-pogo-signature module directly to npm just a few minutes ago!

I suggest we use that, rather than the git link :) Thanks for testing/letting me implement for testing!

https://www.npmjs.com/package/node-pogo-signature
