### PR TITLE
Make CatchStatus optional to tolerant null case.

### DIFF
--- a/pokemon.proto
+++ b/pokemon.proto
@@ -958,7 +958,7 @@ message ResponseEnvelop {
   }
 
   message CatchPokemonResponse {
-      required CatchStatus Status = 1;
+      optional CatchStatus Status = 1;
       optional double MissPercent = 2;
       //optional uint64 CapturedPokemonId = 3;
       //optional CaptureAward CaptureAward = 4;


### PR DESCRIPTION
When player have no more pokeballs or pokemon storages, catch status would be null.
