### PR TITLE
use official npm repo for node-pogo-signature

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "gpsoauthnode": "^0.0.5",
     "istanbul": "^0.4.4",
     "long": "^3.2.0",
-    "node-pogo-signature": "https://github.com/SpencerSharkey/node-pogo-signature.git",
+    "node-pogo-signature": "^2.0.0",
     "protobufjs": "^5.0.1",
     "request": "^2.73.0",
     "s2geometry-node": "^1.3.0",


### PR DESCRIPTION
We're on NPM now!
https://www.npmjs.com/package/node-pogo-signature

No more gross git url
