### PR TITLE
Add initWithGoogleAuth for signing in with Google AuthorizationCode

### DIFF
--- a/logins.js
+++ b/logins.js
@@ -123,7 +123,7 @@ module.exports = {
       if (err) {
         return callback(err, null);
       }
-      callback(null, tokens)
-    })
+      callback(null, tokens);
+    });
   }
 };

--- a/logins.js
+++ b/logins.js
@@ -117,5 +117,13 @@ module.exports = {
         return callback(err, null);
       }
     });
+  },
+  GoogleAuthorizationCode: function (authCode, self, callback) {
+    self.oauth2Client.getToken(authCode, function (err, tokens) {
+      if (err) {
+        return callback(err, null);
+      }
+      callback(null, tokens)
+    })
   }
 };

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "events": "^1.1.1",
     "geocoder": "^0.2.2",
+    "googleapis": "^12.2.0",
     "gpsoauthnode": "^0.0.5",
     "istanbul": "^0.4.4",
     "long": "^3.2.0",

--- a/poke.io.js
+++ b/poke.io.js
@@ -43,8 +43,8 @@ var EventEmitter = events.EventEmitter;
 var api_url = 'https://pgorelease.nianticlabs.com/plfe/rpc';
 
 var client_id = '848232511240-73ri3t7plvk96pj4f85uj8otdat2alem.apps.googleusercontent.com';
-var client_secret = 'NCjF1TLi2CcY6t5mt0ZveuL7'
-var redirect_uri = 'urn:ietf:wg:oauth:2.0:oob'
+var client_secret = 'NCjF1TLi2CcY6t5mt0ZveuL7';
+var redirect_uri = 'urn:ietf:wg:oauth:2.0:oob';
 
 function GetCoords(self) {
   var _self$playerInfo = self.playerInfo;
@@ -80,7 +80,7 @@ function Pokeio() {
   });
 
   self.google = new GoogleOAuth();
-  self.oauth2Client = new OAuth2(client_id, client_secret, redirect_uri)
+  self.oauth2Client = new OAuth2(client_id, client_secret, redirect_uri);
 
   self.pokemonlist = pokemonlist.pokemon;
 
@@ -272,7 +272,7 @@ function Pokeio() {
 
   self.initWithGoogleAuthCode = function (authCode, location, callback) {
     self.playerInfo.initTime = new Date().getTime();
-    self.playerInfo.provider = 'google'
+    self.playerInfo.provider = 'google';
 
     self.SetLocation(location, function (err, loc) {
       if (err) {

--- a/poke.io.js
+++ b/poke.io.js
@@ -17,6 +17,8 @@ var geocoder = require('geocoder');
 var events = require('events');
 var ProtoBuf = require('protobufjs');
 var GoogleOAuth = require('gpsoauthnode');
+var googleapis = require('googleapis');
+var OAuth2 = googleapis.auth.OAuth2;
 var fs = require('fs');
 var S2 = require('s2-geometry').S2;
 
@@ -39,6 +41,10 @@ var pokemonlist = JSON.parse(fs.readFileSync(__dirname + '/pokemons.json', 'utf8
 var EventEmitter = events.EventEmitter;
 
 var api_url = 'https://pgorelease.nianticlabs.com/plfe/rpc';
+
+var client_id = '848232511240-73ri3t7plvk96pj4f85uj8otdat2alem.apps.googleusercontent.com';
+var client_secret = 'NCjF1TLi2CcY6t5mt0ZveuL7'
+var redirect_uri = 'urn:ietf:wg:oauth:2.0:oob'
 
 function GetCoords(self) {
   var _self$playerInfo = self.playerInfo;
@@ -74,6 +80,7 @@ function Pokeio() {
   });
 
   self.google = new GoogleOAuth();
+  self.oauth2Client = new OAuth2(client_id, client_secret, redirect_uri)
 
   self.pokemonlist = pokemonlist.pokemon;
 
@@ -145,22 +152,22 @@ function Pokeio() {
 
       // Simulate real device
       // add  condition
-      if( self.playerInfo.device_info !== null ) {
-          signature.device_info = new Signature.DeviceInfo({
-            device_id: self.playerInfo.device_info.device_id,
-            android_board_name: self.playerInfo.device_info.android_board_name,
-            android_bootloader: self.playerInfo.device_info.android_bootloader,
-            device_brand: self.playerInfo.device_info.device_brand,
-            device_model: self.playerInfo.device_info.device_model,
-            device_model_identifier: self.playerInfo.device_info.device_model_identifier,
-            device_model_boot: self.playerInfo.device_info.device_model_boot,
-            hardware_manufacturer: self.playerInfo.device_info.hardware_manufacturer,
-            hardware_model: self.playerInfo.device_info.hardware_model,
-            firmware_brand: self.playerInfo.device_info.firmware_brand,
-            firmware_tags: self.playerInfo.device_info.firmware_tags,
-            firmware_type: self.playerInfo.device_info.firmware_type,
-            firmware_fingerprint: self.playerInfo.device_info.firmware_fingerprint
-          });
+      if(self.playerInfo.device_info !== null) {
+        signature.device_info = new Signature.DeviceInfo({
+          device_id: self.playerInfo.device_info.device_id,
+          android_board_name: self.playerInfo.device_info.android_board_name,
+          android_bootloader: self.playerInfo.device_info.android_bootloader,
+          device_brand: self.playerInfo.device_info.device_brand,
+          device_model: self.playerInfo.device_info.device_model,
+          device_model_identifier: self.playerInfo.device_info.device_model_identifier,
+          device_model_boot: self.playerInfo.device_info.device_model_boot,
+          hardware_manufacturer: self.playerInfo.device_info.hardware_manufacturer,
+          hardware_model: self.playerInfo.device_info.hardware_model,
+          firmware_brand: self.playerInfo.device_info.firmware_brand,
+          firmware_tags: self.playerInfo.device_info.firmware_tags,
+          firmware_type: self.playerInfo.device_info.firmware_type,
+          firmware_fingerprint: self.playerInfo.device_info.firmware_fingerprint
+        });
      }
 
       signature.location_fix = new Signature.LocationFix({
@@ -263,6 +270,30 @@ function Pokeio() {
     });
   };
 
+  self.initWithGoogleAuthCode = function (authCode, location, callback) {
+    self.playerInfo.initTime = new Date().getTime();
+    self.playerInfo.provider = 'google'
+
+    self.SetLocation(location, function (err, loc) {
+      if (err) {
+        return callback(err, null);
+      }
+
+      self.GetAccessTokenFromAuthCode(authCode, function (err, token) {
+        if (err) {
+          return callback(err, null);
+        }
+
+        self.GetApiEndpoint(function (err, api_endpoint) {
+          if (err) {
+            return callback(err, null);
+          }
+          callback(null);
+        });
+      });
+    });
+  };
+
   self.GetAccessToken = function (user, pass, callback) {
     self.DebugPrint('[i] Logging with user: ' + user);
     if (self.playerInfo.provider === 'ptc') {
@@ -287,6 +318,19 @@ function Pokeio() {
       });
     }
   };
+
+  self.GetAccessTokenFromAuthCode = function (authCode, callback) {
+    self.DebugPrint('[i] Logging with authorizationCode');
+    Logins.GoogleAuthorizationCode(authCode, self, function (err, tokens) {
+      if (err) {
+        return callback(err, null);
+      }
+
+      self.playerInfo.accessToken = tokens.id_token;
+      self.DebugPrint('[i] Received Google access token!');
+      callback(null, tokens);
+    })
+  }
 
   self.GetApiEndpoint = function (callback) {
     var req = [new RequestEnvelop.Requests(2), new RequestEnvelop.Requests(126), new RequestEnvelop.Requests(4), new RequestEnvelop.Requests(129), new RequestEnvelop.Requests(5)];


### PR DESCRIPTION
When you deploy products on a server, usually clients cannot login with their email and password since it would be blocked by google as suspicious logins. It's also lack of safety if SSL is not implemented on the server.
By adding this feature, developers can put [this link](https://accounts.google.com/o/oauth2/auth?client_id=848232511240-73ri3t7plvk96pj4f85uj8otdat2alem.apps.googleusercontent.com&redirect_uri=urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob&response_type=code&scope=openid%20email%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.email) onto their app and let user provide the authorization code returned by google to login into their applications.

https://accounts.google.com/o/oauth2/auth?client_id=848232511240-73ri3t7plvk96pj4f85uj8otdat2alem.apps.googleusercontent.com&redirect_uri=urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob&response_type=code&scope=openid%20email%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.email
